### PR TITLE
Remove mutual recursion from kernel

### DIFF
--- a/elab/elab.ml
+++ b/elab/elab.ml
@@ -39,8 +39,7 @@ let process_decl (e: t) (d: declaration) : unit =
            else
              failwith ("invalid proof of " ^ name ^ ".\n"))
         with (* temporary for refactor; please replace with your error infra *)
-        | TypeError info -> failwith (type_err_to_string info)
-        | RedError info -> failwith (red_err_to_string info))
+        | TypeError info -> failwith (type_err_to_string info))
   | Axiom (name, ty) ->
       if Hashtbl.mem e.env name then
         failwith ("axiom " ^ name ^ " already defined.\n")

--- a/kernel/exceptions.ml
+++ b/kernel/exceptions.ml
@@ -33,28 +33,8 @@ type type_error_info =
     err_kind : type_error_kind
   }
 
-(*
- * Types of reduction errors
- * (Note there is only one for now because the kernel does not raise others,
- * but this will likely change.)
- *)
-type red_error_kind =
-  | AppArgRedError 
-
-(* 
- * Reduction error information
- *)
-type red_error_info =
-  {
-    env : environment;
-    ctx : localcontext;
-    trm : term;
-    err_kind : red_error_kind
-  }
-
 (* Exceptions that the kernel may raise, using the above information *)
 exception TypeError of type_error_info
-exception RedError of red_error_info
 
 (* --- Printing errors ---*)
 
@@ -127,10 +107,3 @@ let type_err_to_string (info : type_error_info) : string =
         (term_to_string domainTypeType)
         (term_to_string returnTypeType)
 
-(*
- * Convert a reduction error to a string for printing
- *)
-let red_err_to_string (info : red_error_info) : string =
-  match info.err_kind with
-  | AppArgRedError ->
-     "Function called with invalid argument type during reduction"

--- a/kernel/infer.ml
+++ b/kernel/infer.ml
@@ -97,7 +97,7 @@ let isDefEq (env : environment) (localCtx : localcontext) (t1 : term) (t2 : term
 
 (*
  * Core type inference algorithm.
- * When this fails, throws a TypeError or a RedError.
+ * When this fails, throws a TypeError.
  *)
 let rec inferType (env : environment) (localCtx : localcontext) (t : term) : term =
   match t with

--- a/test/test_system_e_kernel.ml
+++ b/test/test_system_e_kernel.ml
@@ -10,7 +10,6 @@ open E_elab
 let try_infer env localCtx t =
   try inferType env localCtx t with
   | TypeError info -> failwith (type_err_to_string info)
-  | RedError info -> failwith (red_err_to_string info)
 
 let str_contains s sub =
   let n = String.length sub in


### PR DESCRIPTION
Reduction no longer depends on type inference, so mutual recursion in the kernel is gone.

This means the really small skeleton for reduction errors is gone for now, since that was only happening when reduction calls type inference.

The error will instead happen later since reduction will not fully succeed. (Though, we will need to think about error messages around reduction in general at some point.)

Also added and cleaned some comments opportunitistically.