### PR TITLE
Update license name in dune-project to quiet opam install warning

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -13,7 +13,7 @@
 
 (maintainers "Maintainer Name <maintainer@example.com>")
 
-(license LICENSE)
+(license MIT)
 
 (documentation https://url/to/documentation)
 

--- a/nicegeo.opam
+++ b/nicegeo.opam
@@ -4,7 +4,7 @@ synopsis: "A short synopsis"
 description: "A longer description"
 maintainer: ["Maintainer Name <maintainer@example.com>"]
 authors: ["Author Name <author@example.com>"]
-license: "LICENSE"
+license: "MIT"
 tags: ["add topics" "to describe" "your" "project"]
 homepage: "https://github.com/username/reponame"
 doc: "https://url/to/documentation"


### PR DESCRIPTION
`dune-project` expects a specific license name in the `(license [license])` stanza, where before we just had `LICENSE`. I've put `MIT` there now so we no longer get the following warning:

```console
$ opam install --deps-only --with-test .
[WARNING] Failed checks on nicegeo package definition from source at git+file:///home/kfish/Documents/Programming/OCaml/nicegeo#main:
  warning 62: License doesn't adhere to the SPDX standard, see https://spdx.org/licenses/ : "LICENSE"
```

Now we just get a clean output.