### PR TITLE
Handle errors in env.txt better

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -10,18 +10,22 @@ let () =
   end;
 
   let filename = Sys.argv.(1) in
-  let env = try
-    Elab.Interface.create_with_env ();
-  with Error.ElabError info ->
-    print_endline ("Internal error while processing env.txt: " ^ Error.pp_exn {
-      env=Hashtbl.create 0;
-      kenv=Hashtbl.create 0;
-      metas=Hashtbl.create 0;
-      lctx=Hashtbl.create 0;
-    } info );
-    (* Uncomment this to get a stack trace *)
-    (* raise exn *)
-    exit 255
+  let env =
+    try Elab.Interface.create_with_env ()
+    with Error.ElabError info ->
+      print_endline
+        ("Internal error while processing env.txt: "
+        ^ Error.pp_exn
+            {
+              env = Hashtbl.create 0;
+              kenv = Hashtbl.create 0;
+              metas = Hashtbl.create 0;
+              lctx = Hashtbl.create 0;
+            }
+            info);
+      (* Uncomment this to get a stack trace *)
+      (* raise exn *)
+      exit 255
   in
   let tone = Nice_messages.tone_from_env () in
   try


### PR DESCRIPTION
Instead of just generating a stack trace when the env.txt axioms fail to type check, show a nicer error message (similarly to what we would do for the proofs passed in on the command line) to make debugging/development easier.