### PR TITLE
named reprs in regression tests

### DIFF
--- a/test/synthetic/tests.ml
+++ b/test/synthetic/tests.ml
@@ -28,9 +28,11 @@ let kterm_to_repr (term : Kernel.Term.term) (bound_names : string list) =
     | Lam (ty, body) -> (
         match bound_names with
         | name :: rest_names ->
-            let ty_repr, rest_names = kterm_to_repr_helper ty indent rest_names bvars in
-            let body_repr, rest_names =
-              kterm_to_repr_helper body (indent + 1) rest_names (name :: bvars)
+            let ty_repr, next_bound_names =
+              kterm_to_repr_helper ty indent rest_names bvars
+            in
+            let body_repr, next_next_bound_names =
+              kterm_to_repr_helper body (indent + 1) next_bound_names (name :: bvars)
             in
             ( Printf.sprintf
                 "Lam (%s%s,\n%s  %s\n%s)"
@@ -39,14 +41,16 @@ let kterm_to_repr (term : Kernel.Term.term) (bound_names : string list) =
                 indent_str
                 body_repr
                 indent_str,
-              rest_names )
+              next_next_bound_names )
         | [] -> failwith "Not enough bound names provided in kterm_to_repr input")
     | Forall (ty, ret) -> (
         match bound_names with
         | name :: rest_names ->
-            let ty_repr, rest_names = kterm_to_repr_helper ty indent rest_names bvars in
-            let ret_repr, rest_names =
-              kterm_to_repr_helper ret (indent + 1) rest_names (name :: bvars)
+            let ty_repr, next_bound_names =
+              kterm_to_repr_helper ty indent rest_names bvars
+            in
+            let ret_repr, next_next_bound_names =
+              kterm_to_repr_helper ret (indent + 1) next_bound_names (name :: bvars)
             in
             ( Printf.sprintf
                 "Forall (%s%s,\n%s  %s\n%s)"
@@ -55,12 +59,14 @@ let kterm_to_repr (term : Kernel.Term.term) (bound_names : string list) =
                 indent_str
                 ret_repr
                 indent_str,
-              rest_names )
+              next_next_bound_names )
         | [] -> failwith "Not enough bound names provided in kterm_to_repr input")
     | App (f, arg) ->
-        let f_repr, bound_names = kterm_to_repr_helper f indent bound_names bvars in
-        let arg_repr, bound_names = kterm_to_repr_helper arg indent bound_names bvars in
-        (Printf.sprintf "App (%s, %s)" f_repr arg_repr, bound_names)
+        let f_repr, next_bound_names = kterm_to_repr_helper f indent bound_names bvars in
+        let arg_repr, next_next_bound_names =
+          kterm_to_repr_helper arg indent next_bound_names bvars
+        in
+        (Printf.sprintf "App (%s, %s)" f_repr arg_repr, next_next_bound_names)
     | Sort n -> (Printf.sprintf "Sort %d" n, bound_names)
     | Fvar _ -> failwith "fvar in kterm_to_repr input"
   in


### PR DESCRIPTION
Continuation/alternative to #114 

This is a pretty big conceptual leap. Since #114 implements regression tests by comparing the string representation of kernel terms, nothing enforces that the string representations are actually valid OCaml syntax, or that they even correspond to the kernel term being represented (in this sense `term_to_repr` must be trusted in #114). So, this PR extends the string representation to include names for function arguments and the corresponding name for each Bvar (the de Bruijn index is still present.) However, this is not possible directly, since the kernel terms do not contain the names, but the elaborator-level terms do. So, we instead check the elaborator representation of the axioms, and then also check that those elaborator terms correspond (convert) to the actual kernel terms in the kenv. Note that this does *not* mean trusting the elaborator, only the conversion function (`conv_to_kterm`) which is a straightforward variant-to-variant conversion and the `term_to_repr` function as before (which has been modified to print Bvar names and the representation of the converted-to-kernel input). 

~~It may be desired to actually parse the strings as OCaml syntax to obtain the kernel term and structurally compare those. In that case, this can easily be modified to use OCaml comments so that it can be matched properly.~~ I changed it to be OCaml comments, even though it isn't strictly necessary currently.