### PR TITLE
End of Line fixed to lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Summary

Add `.gitattributes` rules so Dune-generated files such as `nicegeo.opam` are consistently checked in with LF line endings.

## Motivation

On Windows, running `dune build` can cause spurious Git diffs due to LF/CRLF conversion, even when the file content is otherwise unchanged. This makes `nicegeo.opam` appear modified after regeneration.

## Changes

- add `.gitattributes`
- force LF for:
  - `*.opam`
  - `dune-project`
  - OCaml/Dune source files

## Effect

This prevents line-ending-only churn and makes repeated `dune build` runs stable across Unix-like systems and Windows.