### PR TITLE
Add red team tests

### DIFF
--- a/test/kernel/test_infer.ml
+++ b/test/kernel/test_infer.ml
@@ -713,6 +713,7 @@ let test_kernel_reduce () =
 
 (* reduce originally had domainType = arg_type instead of isDefEq, which would cause this to fail *)
 let test_reduce_crashes () =
+  let open Internals in
   let env = mk_env () in
   let ctx = Hashtbl.create 0 in
   Hashtbl.add ctx "p" (Const "Point");
@@ -727,6 +728,7 @@ let test_reduce_crashes () =
 
 (* two Apps makes things not reduce all the way although i'm not sure if this would come up in practice*)
 let test_reduce_stuck () =
+  let open Internals in
   let env = mk_env () in
   let ctx = Hashtbl.create 0 in
   Hashtbl.add ctx "p" (Const "Point");


### PR DESCRIPTION
This adds the tests from https://github.com/nicegeo/nicegeo/tree/red-team (from the start of the class). They succeed without changes, which reflects that the other changes from that branch were already included, or fixed in other ways.

Resolves #35