### PR TITLE
Pass the filled goal type to the tactic runner

### DIFF
--- a/elab/typecheck.ml
+++ b/elab/typecheck.ml
@@ -552,7 +552,7 @@ let process_decl (e : ctx) (d : declaration) : unit =
       | Theorem body ->
           let proof =
             match body with
-            | Proof script -> replace_metas e (Tactic.run e script d.ty)
+            | Proof script -> replace_metas e (Tactic.run e script ty_filled)
             | DefEq proof -> proof
           in
           let proof_filled = elaborate e proof (Some ty_filled) in


### PR DESCRIPTION
otherwise you can't even write a tactic proof for some theorem statements with a cannotinferhole error