### PR TITLE
Use split and destruct_ands in proof mode examples

### DIFF
--- a/ide/examples/proof_mode_tactics.ncg
+++ b/ide/examples/proof_mode_tactics.ncg
@@ -17,9 +17,9 @@ Proof.
   intros A.
   intros B.
   intros h.
-  exact (And.intro B A
-    (And.elim A B B (fun (_a: A) (b: B) => b) h)
-    (And.elim A B A (fun (a: A) (_b: B) => a) h)).
+  split.
+    exact (And.elim A B B (fun (_a: A) (b: B) => b) h).
+    exact (And.elim A B A (fun (a: A) (_b: B) => a) h).
 Qed.
 
 Theorem and_id_tactic : (A: Prop) -> And A A -> A

--- a/ide/examples/proof_mode_tactics.ncg
+++ b/ide/examples/proof_mode_tactics.ncg
@@ -9,7 +9,8 @@ Qed.
 Theorem and_left_tactic : (A: Prop) -> (B: Prop) -> And A B -> A
 Proof.
   intros A B h.
-  exact (And.elim A B A (fun (a: A) (_b: B) => a) h).
+  destruct_ands h a b.
+  exact a.
 Qed.
 
 Theorem and_swap_tactic : (A: Prop) -> (B: Prop) -> And A B -> And B A
@@ -17,13 +18,15 @@ Proof.
   intros A.
   intros B.
   intros h.
+  destruct_ands h a b.
   split.
-    exact (And.elim A B B (fun (_a: A) (b: B) => b) h).
-    exact (And.elim A B A (fun (a: A) (_b: B) => a) h).
+    apply b.
+    apply a.
 Qed.
 
 Theorem and_id_tactic : (A: Prop) -> And A A -> A
 Proof.
   intros A h.
-  exact (And.elim A A A (fun (a: A) (_b: A) => a) h).
+  destruct_ands h a b.
+  exact a.
 Qed.


### PR DESCRIPTION
This was just a way of testing that the interactive proof mode works for me, and that the split tactic also works in a practical context. I just modified the example proofs to use `split` and `destruct_ands`. 