### PR TITLE
Sort names in CONTRIBUTORS alphabetically and add myself to CONTRIBUTORS

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,4 +3,5 @@ This file lists contributors to this project, organized alphabetically. Feel fre
 Charles Pei (char3210)
 Jiayou He (hjy1)
 Kevin Fisher (kfish610)
+Pranav Rajpal (pranavrajpal)
 Priyam Sahoo (priyamsahoo)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,6 +1,6 @@
 This file lists contributors to this project, organized alphabetically. Feel free to add yourself to this list when contributing. 
 
 Charles Pei (char3210)
-Priyam Sahoo (priyamsahoo)
 Jiayou He (hjy1)
 Kevin Fisher (kfish610)
+Priyam Sahoo (priyamsahoo)


### PR DESCRIPTION
The CONTRIBUTORS file says that it lists contributors alphabetically, but they weren't sorted alphabetically previously, so this PR sorts everyone's names alphabetically. I also added myself to the CONTRIBUTORS file in the process.

I know those arguably are two separate changes that deserve different PRs, but creating more than one PR for a change this small seemed like overkill so I included them in the same PR. I can split this up into two PRs if you want though.